### PR TITLE
213 only fetch organizer's events

### DIFF
--- a/client/src/components/Events.js
+++ b/client/src/components/Events.js
@@ -2,21 +2,24 @@ import React, { PropTypes } from 'react';
 import { Link } from 'react-router';
 import EventRow from './EventRow';
 
-function Events({ data }) {
+function Events({ data, isMusician }) {
   const events = data.map(event =>
     <EventRow key={event.id} event={event} />
   );
   return (
     <div className="volunteer-view-events">
       <h3>Events</h3>
-      <Link to="/createEvent">Create Event</Link>
+      { !isMusician && (
+        <Link to="/createEvent">Create Event</Link>
+      ) }
       { events }
     </div>
   );
 }
 
 Events.propTypes = {
-  data: PropTypes.array.isRequired
+  data: PropTypes.array.isRequired,
+  isMusician: PropTypes.bool.isRequired
 };
 
 Events.defaultProps = {

--- a/client/src/containers/EventsAttendingContainer.js
+++ b/client/src/containers/EventsAttendingContainer.js
@@ -1,6 +1,12 @@
 import Events from '../components/Events';
 import gimmeData from '../utils/gimmeData';
-import { getUserId } from '../reducers/userReducer';
+import { isMusician, getUserId } from '../reducers/userReducer';
+
+function mapStateToProps(state) {
+  return {
+    isMusician: isMusician(state)
+  };
+}
 
 const getEventsAttendingUrl = (state) => `users/${getUserId(state)}/eventsAttending`;
-export default gimmeData(getEventsAttendingUrl)(Events);
+export default gimmeData(getEventsAttendingUrl, mapStateToProps)(Events);

--- a/client/src/containers/EventsContainer.js
+++ b/client/src/containers/EventsContainer.js
@@ -10,4 +10,10 @@ function urlFn(state) {
   return `users/${getUserId(state)}/events`;
 }
 
-export default gimmeData(urlFn)(Events);
+function mapStateToProps(state) {
+  return {
+    isMusician: isMusician(state)
+  };
+}
+
+export default gimmeData(urlFn, mapStateToProps)(Events);

--- a/client/src/containers/EventsContainer.js
+++ b/client/src/containers/EventsContainer.js
@@ -1,4 +1,13 @@
 import Events from '../components/Events';
+import { isMusician, getUserId } from '../reducers/userReducer';
 import gimmeData from '../utils/gimmeData';
 
-export default gimmeData('events')(Events);
+function urlFn(state) {
+  if (isMusician(state)) {
+    return 'events';
+  }
+
+  return `users/${getUserId(state)}/events`;
+}
+
+export default gimmeData(urlFn)(Events);


### PR DESCRIPTION
This PR closes #213 and closes #215 

#### What does this PR do?
- change fetch for organizers to only get their events. Normally I'd filter on UI too in case their is stale state, but I don't know if it's needed here (??)
- remove 'create event' from musician dashboard

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](http://i.giphy.com/3o6gaW2l0FJB0jt7MY.gif)

