### PR TITLE
fetch organizations and redirect after event create #212 #211

### DIFF
--- a/client/src/actions/eventActions.js
+++ b/client/src/actions/eventActions.js
@@ -1,7 +1,7 @@
 import { browserHistory } from 'react-router';
 import { createApiAction, createAction, createErrorAction } from '../utils/reduxActions';
 import { put } from '../utils/apiHelpers';
-import { getUserId } from '../reducers/userReducer';
+import { getUserId, getUser } from '../reducers/userReducer';
 import {
   SIGNUP_FOR_EVENT_FAILURE,
   SIGNUP_FOR_EVENT_SUCCESS,
@@ -14,8 +14,14 @@ export function createEvent(formData) {
   return apiAction('post', (state) => `users/${getUserId(state)}/events`, {
     body: correctDatesForKeys(formData, ['date', 'endDate']),
 
-    onSuccess: (res) => {
-      browserHistory.push(`/event/${res.id}`);
+    onSuccess: (res, state) => {
+      const organizations = getUser(state).organizations || [];
+      if (organizations.length) {
+        browserHistory.push('/events');
+        return;
+      }
+
+      browserHistory.push('/organizerProfile');
     }
   });
 }

--- a/client/src/actions/modelActions.js
+++ b/client/src/actions/modelActions.js
@@ -27,7 +27,7 @@ export function apiAction(method, urlFn, { body, urlParams, onSuccess } = {}) {
       dispatch(apiActionSuccess(response, metaData));
 
       if (typeof onSuccess === 'function') {
-        onSuccess(response);
+        onSuccess(response, getState());
       }
     } catch (apiError) {
       dispatch(apiActionFail(apiError, metaData));

--- a/client/src/containers/CreateEventContainer.js
+++ b/client/src/containers/CreateEventContainer.js
@@ -1,10 +1,14 @@
-import { connect } from 'react-redux';
+import gimmeData from '../utils/gimmeData';
 import { createEvent } from '../actions/eventActions';
-
 import CreateEvent from '../components/CreateEvent';
+import { getUserId } from '../reducers/userReducer';
+
+function urlFn(state) {
+  return `users/${getUserId(state)}/organization`;
+}
 
 const mapDispatchToProps = {
   onSubmit: createEvent
 };
 
-export default connect(null, mapDispatchToProps)(CreateEvent);
+export default gimmeData(urlFn, null, mapDispatchToProps)(CreateEvent);

--- a/client/src/utils/urlParsing.js
+++ b/client/src/utils/urlParsing.js
@@ -9,6 +9,7 @@ const modelAliases = {
 
   eventVolunteers: 'eventVolunteers',
   organizations: 'organizations',
+  organization: 'organization',
 };
 
 function getModelAlias(name) {

--- a/common/models/user.json
+++ b/common/models/user.json
@@ -17,7 +17,7 @@
         "string"
       ]
     }
-    
+
   },
   "validations": [],
   "relations": {
@@ -27,7 +27,7 @@
       "foreignKey": "ownerId"
     },
     "organization": {
-      "type": "hasOne",
+      "type": "hasMany",
       "model": "Organization",
       "foreignKey": "adminId"
     },

--- a/server/boot/sample-models.js
+++ b/server/boot/sample-models.js
@@ -96,4 +96,13 @@ module.exports = function (app) {
 
     console.log('Created events:', events);
   });
+
+  var Organization = app.models.Organization;
+  var organization = [];
+
+  Organization.create(organization, function(err) {
+    if (err) throw err;
+
+    console.log('Created empty organizations');
+  });
 };


### PR DESCRIPTION
This PR closes #212 and closes #211 

#### What does this PR do?
After creating an event, if the user doesn't have an organization, redirect to the organizerProfile page. Otherwise, go to /events

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![](http://i.giphy.com/vKmHoLAQSKKhW.gif)

