### PR TITLE
username in header is now link to proper profile page

### DIFF
--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -5,13 +5,14 @@ class Header extends React.Component {
   static propTypes = {
     isLoggedIn: PropTypes.bool.isRequired,
     logoutUser: PropTypes.func.isRequired,
-    user: PropTypes.object
+    user: PropTypes.object,
+    isMusician: PropTypes.bool.isRequired
   };
 
   render() {
     const loggedIn = (
       <div>
-        Hello, {this.props.user.email}
+        Hello, <Link to={this.props.isMusician ? '/musicianProfile' : 'organizerProfile'}>{this.props.user.email}</Link>
         {' '}
         <button className="button" onClick={this.props.logoutUser}>Log out</button>
       </div>

--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -12,7 +12,7 @@ class Header extends React.Component {
   render() {
     const loggedIn = (
       <div>
-        Hello, <Link to={this.props.isMusician ? '/musicianProfile' : 'organizerProfile'}>{this.props.user.email}</Link>
+        Hello, <Link to={this.props.isMusician ? '/musicianProfile' : '/organizerProfile'}>{this.props.user.email}</Link>
         {' '}
         <button className="button" onClick={this.props.logoutUser}>Log out</button>
       </div>

--- a/client/src/containers/HeaderContainer.js
+++ b/client/src/containers/HeaderContainer.js
@@ -1,12 +1,13 @@
 import { connect } from 'react-redux';
 import { logoutUser } from '../actions/userActions';
-import { isLoggedIn, getUser } from '../reducers/userReducer';
+import { isLoggedIn, getUser, isMusician } from '../reducers/userReducer';
 import Header from '../components/Header';
 
 const mapStateToProps = (state) => {
   return {
     isLoggedIn: isLoggedIn(state),
-    user: getUser(state)
+    user: getUser(state),
+    isMusician: isMusician(state)
   };
 };
 


### PR DESCRIPTION
This PR closes #[insert associated issue number here]

#### What does this PR do?
If the logged in user is a musician, the username in the header links to the musicianProfilePage. Otherwise, it links to the organizerProfilePage.

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)

![http://i.giphy.com/jKaFXbKyZFja0.gif](put .gif link here - can be found under "advanced" on giphy)
