### PR TITLE
Fixed 'login redirect broken' #310

### DIFF
--- a/client/src/containers/RegisterContainer.js
+++ b/client/src/containers/RegisterContainer.js
@@ -1,12 +1,14 @@
 import { connect } from 'react-redux';
 import { registerRequest } from '../actions/userActions';
-import { userIsBeingFetched } from '../reducers/userReducer';
+import { userIsBeingFetched, isLoggedIn, isMusician } from '../reducers/userReducer';
 
 import Register from '../components/Register';
 
 const mapStateToProps = (state) => {
   return {
-    isFetching: userIsBeingFetched(state)
+    isFetching: userIsBeingFetched(state),
+    isLoggedIn: isLoggedIn(state),
+    isMusician: isMusician(state)
   };
 };
 


### PR DESCRIPTION
This PR closes #[insert associated issue number here]

#### What does this PR do?

Prior to this PR, if a user were to register and mark themselves as a musician, they would NOT be redirected to the events page as they normally would. This PR fixes that, by adding (re-adding?) reducers that were missing in the `registerContainer.js` file.

#### How does this PR make you feel? [:link:](http://giphy.com/categories/emotions/)
![](https://media.giphy.com/media/WIg8P0VNpgH8Q/giphy.gif)

Thanks @fredmon3!