### PR TITLE
bugfix: move link to new dashboard

### DIFF
--- a/client/src/components/Events.js
+++ b/client/src/components/Events.js
@@ -1,5 +1,4 @@
 import React, { PropTypes } from 'react';
-import { Link } from 'react-router';
 import EventRow from './EventRow';
 
 function Events({ data, isMusician }) {

--- a/client/src/components/Events.js
+++ b/client/src/components/Events.js
@@ -14,9 +14,6 @@ function Events({ data, isMusician }) {
           <h3>Events</h3>
         </div>
       </div>
-      { !isMusician && (
-        <Link to="/createEvent">Create Event</Link>
-      ) }
       { events }
     </div>
   );

--- a/client/src/components/OrganizerDashboard.js
+++ b/client/src/components/OrganizerDashboard.js
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
-import EventRow from './EventRow';
 import { Link } from 'react-router';
+import EventRow from './EventRow';
 import { PENDING, APPROVED } from '../constants/eventAttendingStatus';
 import EventVolunteerRow from '../components/EventVolunteerRow';
 

--- a/client/src/components/OrganizerDashboard.js
+++ b/client/src/components/OrganizerDashboard.js
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import EventRow from './EventRow';
+import { Link } from 'react-router';
 import { PENDING, APPROVED } from '../constants/eventAttendingStatus';
 import EventVolunteerRow from '../components/EventVolunteerRow';
 
@@ -29,6 +30,7 @@ const OrganizerDashboard = ({ data, approveEventMusician, rejectEventMusician })
     <div className="row">
       <div className="small-10">
         <h3>Dashboard</h3>
+        <Link to="/createEvent">Create Event</Link>
         <br />
         <div className="card">
           <div className="card-divider">


### PR DESCRIPTION
Earlier PR that removed `/events` for organizers misssed bringing this link over