### PR TITLE
Add over21 to user model

### DIFF
--- a/common/models/user.json
+++ b/common/models/user.json
@@ -18,6 +18,9 @@
     "phoneNumber": {
       "type": "string"
     },
+    "over21": {
+      "type": "boolean"
+    },
     "link": {
       "type": "string"
     },


### PR DESCRIPTION
This PR closes #378 

#### What does this PR do?

This adds `over21` `{ type: boolean }`  property to user model.  The db schema now has the `over21` column and that data is persisted when the over21 checkbox is clicked and saved.

#### How does this PR make you feel?   Happy to help!!!    😀 

![](https://media.giphy.com/media/Zw3oBUuOlDJ3W/giphy.gif)
